### PR TITLE
Add automatic renaming for files with duplicate names

### DIFF
--- a/Automatization/Logic/WordTemplateProcessor.cs
+++ b/Automatization/Logic/WordTemplateProcessor.cs
@@ -34,5 +34,27 @@ namespace Automatization.Logic
                 wordDoc.MainDocumentPart.Document.Save();
             }
         }
+
+        public static string GetUniqueFileName(string fileName, string directory)
+        {
+            string filePath = fileName;
+            string originalFileName = fileName;
+            int counter = 1;
+
+            // Проверяем, существует ли файл, и добавляем (1), (2), ... до тех пор, пока не найдем свободное имя
+            while (File.Exists(filePath))
+            {
+                string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(originalFileName);
+                string extension = Path.GetExtension(originalFileName);
+
+                // Формируем новое имя с суффиксом (1), (2) и т. д.
+                fileName = $"{fileNameWithoutExtension} ({counter}){extension}";
+                filePath = Path.Combine(directory, fileName);
+                counter++;
+            }
+
+            return filePath;
+        }
+
     }
 }

--- a/Automatization/Windows/MainWindow.axaml.cs
+++ b/Automatization/Windows/MainWindow.axaml.cs
@@ -36,32 +36,48 @@ namespace Automatization.Windows
                 if (confirm.ShouldContinue)
                 {
                     // Продолжаем создание документа даже с пустыми полями
-                    string templatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Templates", "template.docx");
-                    string documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-                    string outputFile = Path.Combine(documentsPath, Name.Text + " — шаблонный.docx");
-
-                    var replacements = new Dictionary<string, string>
-                    {
-                        { "{{Name}}", Name.Text },
-                        { "{{Animal}}", Animal.Text },
-                        { "{{Comment}}", Comment.Text }
-                    };
-
-                    try
-                    {
-                        TemplateProcessor.CreateDocumentFromTemplate(templatePath, outputFile, replacements);
-                        ControlStyler.MessageTextBlock(MessageTextBlock, 1, "Документ создан!");
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        ControlStyler.MessageTextBlock(MessageTextBlock, 2, "Шаблон не найден.");  // Если шаблон не найден
-                    }
+                    DocumentCreation();
                 }
                 else
                 {
                     // Пользователь отменил действие
                     ControlStyler.HighlightAll(Name, Animal, Comment);
                 }
+            }
+            else
+            {
+                DocumentCreation();
+            }
+        }
+
+        private void DocumentCreation()
+        {
+            string templatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Templates", "template.docx");
+
+            // Получаем путь к папке «Документы»
+            string documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+
+            // Начальное имя файла
+            string outputFileName = Path.Combine(documentsPath, Name.Text + " — шаблонный.docx");
+
+            // Получаем уникальное имя для файла
+            string uniqueFileName = WordTemplateProcessor.GetUniqueFileName(outputFileName, documentsPath);
+
+            var replacements = new Dictionary<string, string>
+            {
+                { "{{Name}}", Name.Text },
+                { "{{Animal}}", Animal.Text },
+                { "{{Comment}}", Comment.Text }
+            };
+
+            try
+            {
+                TemplateProcessor.CreateDocumentFromTemplate(templatePath, uniqueFileName, replacements);
+                ControlStyler.MessageTextBlock(MessageTextBlock, 1, "Документ создан!");
+            }
+            catch (FileNotFoundException)
+            {
+                ControlStyler.MessageTextBlock(MessageTextBlock, 2, "Шаблон не найден.");  // Если шаблон не найден
             }
         }
         private void TextBox_KeyUp(object? sender, Avalonia.Input.KeyEventArgs e)


### PR DESCRIPTION
When a file with the same name already exists, a number (e.g., (1), (2), etc.) is added to the new file to avoid overwriting the previous ones.